### PR TITLE
Add epub support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ help:
 	@echo "  htmlhelp  to make HTML files and a HTML help project"
 	@echo "  qthelp    to make HTML files and a qthelp project"
 	@echo "  latex     to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
+	@echo "  epub      to make an epub file"
 	@echo "  changes   to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck to check all external links for integrity"
 	@echo "  doctest   to run all doctests embedded in the documentation (if enabled)"
@@ -84,6 +85,11 @@ latex:
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
 	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \
 	      "run these through (pdf)latex."
+
+epub:
+	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
+	@echo
+	@echo "Build finished. The epup file is in in $(BUILDDIR)/epub."
 
 changes:
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes


### PR DESCRIPTION
I wanted to read the book on my kindle, so I added an epub target to the makefile as sphinx already supports this.

This epub file was converted to .mobi via calibre. See https://github.com/mitsuhiko/flask/issues/388 for more information.

 Worked quite fine, except for the copyright at the bottom of each chapter: http://oi39.tinypic.com/96fec8.jpg
